### PR TITLE
Add Intel build config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 better-sqlite3:ignore-scripts=true
 electron-deeplink:ignore-scripts=true
-sharp:ignore-scripts=true
+

--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ node --version
 npm run setup
 ```
 
+### Intel Mac Build
+
+To build on an Intel-based Mac you need to install native modules for the x86_64 architecture and create an x64 package.
+
+```bash
+# rebuild native dependencies for x86_64
+npm install --arch=x64
+
+# make an Intel build
+npm run make:x64
+```
+
+Ensure that `src/assets/SystemAudioDump` contains an x86_64 or universal binary. If you have the source, compile it for x86_64 or merge with the ARM64 build using `lipo -create`.
+
 ## Highlights
 
 

--- a/forge.config.js
+++ b/forge.config.js
@@ -23,7 +23,9 @@ module.exports = {
             "**/*.node",
             "**/*.dylib",
             "node_modules/@img/sharp-darwin-arm64/**",
-            "node_modules/@img/sharp-libvips-darwin-arm64/**"
+            "node_modules/@img/sharp-libvips-darwin-arm64/**",
+            "node_modules/@img/sharp-darwin-x64/**",
+            "node_modules/@img/sharp-libvips-darwin-x64/**"
         ],
         osxSign: {
             identity: process.env.APPLE_SIGNING_IDENTITY,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "start": "npm run build:renderer && electron-forge start",
         "package": "npm run build:renderer && electron-forge package",
         "make": "npm run build:renderer && electron-forge make",
+        "make:x64": "npm run build:renderer && electron-forge make --arch=x64",
         "build": "npm run build:renderer && electron-builder --config electron-builder.yml --publish never",
         "publish": "npm run build:renderer && electron-builder --config electron-builder.yml --publish always",
         "lint": "eslint --ext .ts,.tsx,.js .",


### PR DESCRIPTION
## Summary
- add instructions for building on x86_64 Macs
- remove sharp ignore rule so native modules can compile
- unpack x64 Sharp binaries when packaging
- add `make:x64` npm script for Intel builds

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build:renderer` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_6867329bc844832481193c50ed3f4dd2